### PR TITLE
Add Render deploy build info and cache control

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,13 @@
+services:
+  - type: web
+    name: vancomyzer
+    env: python
+    plan: starter
+    buildCommand: bash scripts/render_build.sh
+    startCommand: python -m uvicorn backend.server:app --host 0.0.0.0 --port $PORT
+    healthCheckPath: /health
+    envVars:
+      - key: APP_NAME
+        value: Vancomyzer
+      - key: APP_VERSION
+        value: v1

--- a/scripts/render_build.sh
+++ b/scripts/render_build.sh
@@ -16,4 +16,14 @@ mkdir -p backend/static
 rm -rf backend/static/*
 cp -R dist/* backend/static/
 
-echo "Render build complete: backend/static populated from dist/"
+BUILD_TIME="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+GIT_SHA="${RENDER_GIT_COMMIT:-}"
+if [ -z "$GIT_SHA" ]; then
+  GIT_SHA="$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")"
+fi
+
+cat > backend/static/build-info.json <<EOF
+{"git_sha":"$GIT_SHA","build_time":"$BUILD_TIME"}
+EOF
+
+echo "Render build complete: backend/static populated from dist/ (git=$GIT_SHA)"


### PR DESCRIPTION
Include a Render config, embed build metadata for version endpoints, and disable HTML caching so new deployments show immediately.